### PR TITLE
Improve macos build by prepending CMAKE_SOURCE_DIR to -FSDK/Libraries/Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if (APPLE)
     target_link_libraries(Hello-World "-framework CoreFoundation")
     target_link_libraries(Hello-World "-framework XPWidgets")
     target_link_libraries(Hello-World "-framework XPLM")
-    set_target_properties(Hello-World PROPERTIES LINK_FLAGS "-Wl,-F/Library/Frameworks, -Wl,-FSDK/Libraries/Mac\
+    set_target_properties(Hello-World PROPERTIES LINK_FLAGS "-Wl,-F/Library/Frameworks, -Wl,-F${CMAKE_SOURCE_DIR}/SDK/Libraries/Mac\
     -Wl,-exported_symbol -Wl,_XPluginStart\
     -Wl,-exported_symbol -Wl,_XPluginEnable\
     -Wl,-exported_symbol -Wl,_XPluginReceiveMessage\


### PR DESCRIPTION
Dear Phillipp,
first of all thank you for your work on X-Plane and for providing valuable information such as this Hello-World project.

I tried building the plugin via  `cmake -S . -B build; cd build ; make` after I had checked out the SDK submodule. However the SDKL lib could not be found, because I built in the "build" directory. Using `-F${CMAKE_SOURCE_DIR}/SDK/Libraries/Mac` instead of just `-FSDK/Libraries/Mac` in the CMakeLists.txt solves it for me. Maybe you want to consider my change.

Best regards und Grüße aus Frankfurt,
Matteo